### PR TITLE
fix: repair broken record_winner API handler (undefined db + wrong signature)

### DIFF
--- a/src/routes/api/shots/+server.js
+++ b/src/routes/api/shots/+server.js
@@ -156,31 +156,99 @@ async function handleRecordShot(request, shotData) {
 }
 
 /**
- * Handle winner recording
+ * Handle winner recording with JWT authentication
  */
-async function handleRecordWinner(winnerData) {
+async function handleRecordWinner(request, winnerData) {
   try {
-    console.log('🏆 Recording winner via API:', {
+    // Validate and extract wallet address from JWT
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return json(
+        { success: false, error: 'Authorization header required' },
+        { status: 401 }
+      );
+    }
+
+    const token = authHeader.substring(7);
+    let walletAddress;
+
+    try {
+      const payload = verifyJWTSecure(token);
+      walletAddress = payload.walletAddress || payload.wallet_address || payload.sub;
+
+      if (!walletAddress) {
+        console.error('❌ JWT payload missing wallet address:', payload);
+        return json(
+          { success: false, error: 'Invalid token: no wallet address' },
+          { status: 401 }
+        );
+      }
+    } catch (jwtError) {
+      console.error('❌ JWT verification failed:', jwtError);
+      return json(
+        { success: false, error: 'Invalid or expired token' },
+        { status: 401 }
+      );
+    }
+
+    // Verify the wallet address matches the winner data
+    if (!winnerData.winnerAddress ||
+        walletAddress.toLowerCase() !== winnerData.winnerAddress.toLowerCase()) {
+      return json(
+        { success: false, error: 'Wallet address mismatch' },
+        { status: 403 }
+      );
+    }
+
+    // Check if server-side Supabase is available
+    if (!isSupabaseServerAvailable()) {
+      console.error('❌ Server-side Supabase not configured');
+      return json(
+        {
+          success: false,
+          error: 'Server configuration error. Please check environment variables.'
+        },
+        { status: 500 }
+      );
+    }
+
+    console.log('🏆 Recording winner via secure API:', {
       winnerAddress: winnerData.winnerAddress,
       amount: winnerData.amount,
       txHash: winnerData.txHash
     });
 
-    const result = await db.recordWinner({
-      winnerAddress: winnerData.winnerAddress,
-      amount: winnerData.amount,
-      txHash: winnerData.txHash,
-      blockNumber: winnerData.blockNumber,
-      timestamp: winnerData.timestamp || new Date().toISOString(),
-      cryptoType: winnerData.cryptoType || 'ETH',
-      contractAddress: winnerData.contractAddress
+    // Use Supabase client with JWT authentication + the record_winner_secure RPC,
+    // mirroring handleRecordShot. The RPC re-verifies the wallet address server-side.
+    const supabase = getSupabaseJWTClient(token);
+
+    const { data, error } = await supabase.rpc('record_winner_secure', {
+      p_winner_address: winnerData.winnerAddress.toLowerCase(),
+      p_amount: winnerData.amount,
+      p_tx_hash: winnerData.txHash,
+      p_block_number: winnerData.blockNumber,
+      p_timestamp: winnerData.timestamp || new Date().toISOString(),
+      p_crypto_type: winnerData.cryptoType || 'ETH',
+      p_contract_address: winnerData.contractAddress
     });
 
-    console.log('✅ Winner recorded successfully via API:', result?.id);
+    if (error) {
+      console.error('❌ Supabase winner recording error:', error);
+      return json(
+        {
+          success: false,
+          error: 'Failed to record winner',
+          message: error.message
+        },
+        { status: 500 }
+      );
+    }
+
+    console.log('✅ Winner recorded successfully via secure API:', data);
 
     return json({
       success: true,
-      winner: result,
+      winner: data,
       message: 'Winner recorded successfully'
     });
 


### PR DESCRIPTION
## Problem

The `record_winner` action in `src/routes/api/shots/+server.js` **always returns HTTP 500** — it can never record a winner. Two bugs:

1. **Signature mismatch.** The dispatcher calls `handleRecordWinner(request, data)` (line 21), but the function was declared `handleRecordWinner(winnerData)` (line 161). So `winnerData` was bound to the SvelteKit `Request` object, and `winnerData.winnerAddress` was always `undefined`.
2. **Undefined `db`.** The body called `db.recordWinner(...)`, but `db` is never imported in this module (it only imports `verifyJWTSecure`, `getSupabaseJWTClient`, `isSupabaseServerAvailable`). `db.recordWinner` is also a **browser-only** function (reads `localStorage`), so it could never run server-side. Every call throws `ReferenceError` → HTTP 500.

By contrast, the sibling `record_shot` handler works correctly.

## Fix

Rewrite `handleRecordWinner` to mirror the working `handleRecordShot`:

- Correct `(request, winnerData)` signature.
- Verify the Bearer JWT via `verifyJWTSecure`; reject missing/invalid tokens (401).
- Confirm the token's wallet matches `winnerData.winnerAddress` (403 on mismatch).
- Insert via the **existing `record_winner_secure` RPC** (defined in `supabase/migrations/20250728150500_simplify_shot_recording.sql`, already `GRANT`ed to `authenticated`), called through `getSupabaseJWTClient(token)`.

Using the existing RPC (rather than a raw table insert) matches how `handleRecordShot` records shots, and the RPC re-verifies the wallet address server-side (defense in depth) — so there's no RLS ambiguity. No `db` reference remains; `node --check` passes.

## Impact

Restores the winner-recording endpoint, which is currently 100% broken.